### PR TITLE
show recent and oldest remote branches

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -12,7 +12,9 @@
   di = diff
   lp = log -p
   st = status
-  # takes args of refbranch (defaults to main) and count (for number of branches to show)
+  # Show most recent and oldest remote branches by committerdate
+  #
+  # Takes arguments of refbranch (defaults to main) and count (for number of branches to show)
   recentb = "!r() { refbranch=$1 count=$2; git for-each-ref --sort=-committerdate refs/remotes --format='%(refname:short)|%(HEAD)%(color:yellow)%(refname:short)|%(color:bold green)%(committerdate:relative)|%(color:blue)%(subject)|%(color:magenta)%(authorname)%(color:reset)' --color=always --count=${count:-20} | while read line; do branch=$(echo \"$line\" | awk 'BEGIN { FS = \"|\" }; { print $1 }' | tr -d '*'); ahead=$(git rev-list --count \"${refbranch:-origin/main}..${branch}\"); behind=$(git rev-list --count \"${branch}..${refbranch:-origin/main}\"); colorline=$(echo \"$line\" | sed 's/^[^|]*|//'); echo \"$ahead|$behind|$colorline\" | awk -F'|' -vOFS='|' '{$5=substr($5,1,70)}1' ; done | ( echo \"ahead|behind||branch|lastcommit|message|author\\n\" && cat) | column -ts'|';}; r"
   oldestb = "!r() { refbranch=$1 count=$2; git for-each-ref --sort=committerdate refs/remotes --format='%(refname:short)|%(HEAD)%(color:yellow)%(refname:short)|%(color:bold green)%(committerdate:relative)|%(color:blue)%(subject)|%(color:magenta)%(authorname)%(color:reset)' --color=always --count=${count:-20} | while read line; do branch=$(echo \"$line\" | awk 'BEGIN { FS = \"|\" }; { print $1 }' | tr -d '*'); ahead=$(git rev-list --count \"${refbranch:-origin/main}..${branch}\"); behind=$(git rev-list --count \"${branch}..${refbranch:-origin/main}\"); colorline=$(echo \"$line\" | sed 's/^[^|]*|//'); echo \"$ahead|$behind|$colorline\" | awk -F'|' -vOFS='|' '{$5=substr($5,1,70)}1' ; done | ( echo \"ahead|behind||branch|lastcommit|message|author\\n\" && cat) | column -ts'|';}; r"
 

--- a/.gitconfig
+++ b/.gitconfig
@@ -12,6 +12,9 @@
   di = diff
   lp = log -p
   st = status
+  # takes args of refbranch (defaults to main) and count (for number of branches to show)
+  recentb = "!r() { refbranch=$1 count=$2; git for-each-ref --sort=-committerdate refs/remotes --format='%(refname:short)|%(HEAD)%(color:yellow)%(refname:short)|%(color:bold green)%(committerdate:relative)|%(color:blue)%(subject)|%(color:magenta)%(authorname)%(color:reset)' --color=always --count=${count:-20} | while read line; do branch=$(echo \"$line\" | awk 'BEGIN { FS = \"|\" }; { print $1 }' | tr -d '*'); ahead=$(git rev-list --count \"${refbranch:-origin/main}..${branch}\"); behind=$(git rev-list --count \"${branch}..${refbranch:-origin/main}\"); colorline=$(echo \"$line\" | sed 's/^[^|]*|//'); echo \"$ahead|$behind|$colorline\" | awk -F'|' -vOFS='|' '{$5=substr($5,1,70)}1' ; done | ( echo \"ahead|behind||branch|lastcommit|message|author\\n\" && cat) | column -ts'|';}; r"
+  oldestb = "!r() { refbranch=$1 count=$2; git for-each-ref --sort=committerdate refs/remotes --format='%(refname:short)|%(HEAD)%(color:yellow)%(refname:short)|%(color:bold green)%(committerdate:relative)|%(color:blue)%(subject)|%(color:magenta)%(authorname)%(color:reset)' --color=always --count=${count:-20} | while read line; do branch=$(echo \"$line\" | awk 'BEGIN { FS = \"|\" }; { print $1 }' | tr -d '*'); ahead=$(git rev-list --count \"${refbranch:-origin/main}..${branch}\"); behind=$(git rev-list --count \"${branch}..${refbranch:-origin/main}\"); colorline=$(echo \"$line\" | sed 's/^[^|]*|//'); echo \"$ahead|$behind|$colorline\" | awk -F'|' -vOFS='|' '{$5=substr($5,1,70)}1' ; done | ( echo \"ahead|behind||branch|lastcommit|message|author\\n\" && cat) | column -ts'|';}; r"
 
 [push]
 	default = current


### PR DESCRIPTION
via gitconfig aliases...examples:

most recent remote branches
```
[~/src/oss/rails (main)] [141] > git recentb
ahead  behind  branch                                      lastcommit          message                                                                author
706    3170     origin/7-0-stable                      8 hours ago   Merge pull request #46581 from cjilbert504/patch-2                 Eileen M. Uchitelle
0      0        origin/HEAD                            11 hours ago  Fix wrong grammar on upgrade guide                                 Rafael Mendonça França
0      0        origin/main                            11 hours ago  Fix wrong grammar on upgrade guide                                 Rafael Mendonça França
603    7131     origin/6-1-stable                      22 hours ago  Add cgi 0.3.6 to Gemfile                                           Jean Boussier
0      40       origin/case-check                      4 days ago    Fix incorrect caching of case-insensitivity                        Phil Pirozhkov
2      107      origin/modern-autoload-paths           7 days ago    Watch all reloadable root directories                              Xavier Noria
987    12219    origin/6-0-stable                      4 weeks ago   Merge pull request #46269 from codergeek121/fix-xss-on-route-erro  Jean Boussier
28     390      origin/extract-base-into-methods-b     6 weeks ago   fix missing var                                                    eileencodes
22     417      origin/extract-base-into-methods       7 weeks ago   Debug failing tests on CI                                          eileencodes
0      417      origin/debugging                       7 weeks ago   Merge pull request #46241 from skipkayhil/fix-migration-compat-in  Yasuo Honda
3      516      origin/check-if-yjit-is-enabled        9 weeks ago   does this work                                                     eileencodes
1      530      origin/no-syntax-error                 9 weeks ago   Remove syntax error exception mutations                            Aaron Patterson
21     692      origin/temp-conn-stable-branch         2 months ago  fix some issues in failing CI                                      eileencodes
843    19221    origin/5-2-stable                      3 months ago  Merge pull request #46040 from eitoball/fix-typo-in-activerecord-  Eileen M. Uchitelle
1      888      origin/trigger-build                   3 months ago  Try CI                                                             Jean Boussier
17     926      origin/use-temp-pool-for-migrations    3 months ago  more wip.                                                          eileencodes
3      1520     origin/upgrade-zeitwerk                6 months ago  Update Gemfile.lock                                                Xavier Noria
0      1681     origin/allow-setting-db-with-postgres  6 months ago  Allow setting db with use_postgresql tests                         eileencodes
```

oldest remote branches:

```
[~/src/oss/rails (main)]> git oldestb

[ snipped some errors here, probably due to Rails switching from master to main way back when ]

ahead  behind  branch                                              lastcommit                    message                                                                author
341    81167    origin/1-2-stable                              15 years ago            Remove wasteful signal trap from transactions. Backport from 2-0-  Jeremy Kemper
77     79255    origin/2-0-stable                              13 years ago            Remove redundant checks for valid character regexp in ActiveSuppo  Beau Harrington
122    77115    origin/2-2-stable                              12 years ago            Change the CSRF whitelisting to only apply to get requests         Michael Koziarski
313    78380    origin/2-1-stable                              12 years ago            Change the CSRF whitelisting to only apply to get requests         Michael Koziarski
909    76162    origin/2-3-stable                              10 years ago            allow the branch to be managed with a modern rake                  Xavier Noria
1625   67740    origin/3-0-stable                              9 years ago             Use the reference for the mime type to get the format              Rafael Mendonça França
1760   62628    origin/3-1-stable                              8 years ago             correctly escape backslashes in request path globs                 Aaron Patterson
1083   48162    origin/4-0-stable                              8 years ago             Merge pull request #19828 from JuanitoFatas/patch-2                Arthur Nogueira Neves
500    37335    origin/fix-find-root-on-ruby-2-2               8 years ago             Use Dir.glob in find_root_with_flag to return correct case         Andrew White
(null)
237    27473    origin/matthewd/inotify                        6 years ago             Focus testing to what we care about                                Matthew Draper
853    43080    origin/4-1-stable                              6 years ago             Merge branch '4-1-16' into 4-1-stable                              Rafael Mendonça França
1848   58666    origin/3-2-stable                              6 years ago             Remove `DEFAULT NULL` for primary key column to support MySQL 5.7  Yasuo Honda
0      22025    origin/verify-release                          5 years ago             Update release instructions in light of new tasks.                 Kasper Timm Hansen
1      21919    origin/fix-duration-modulo                     5 years ago             Add missing support for modulo operations on durations             Sayan Chakraborty
1      20977    origin/proxy-pg-result                         5 years ago             Reduce Array object allocations when querying PG                   Aaron Patterson
2      20847    origin/railties-split                          5 years ago             Split railties suite in half                                       Matthew Draper
420    23520    origin/backport-30638                          5 years ago             Puma Rack handler is required by Capybara                          Guillermo Iguaran
1      20104    origin/record-timezone-when-writing-from-user  5 years ago             Record timezone in use when writing an attribute                   Andrew White
1      19581    origin/use-any-bundler                         4 years, 11 months ago
```
